### PR TITLE
assign pb/@xml:id from surface filename, not surface/@xml:id

### DIFF
--- a/xml/xslt/reconstitute.xsl
+++ b/xml/xslt/reconstitute.xsl
@@ -15,11 +15,7 @@
 	<xsl:variable name="page-identifier-regex" select="//c:body[contains(@disposition, 'name=&#34;page-identifier-regex&#34;')]"/>
 	
 	<!-- a full TEI file will be regenerated from the TEI surface files generated at the time of ingestion into Nyingarn -->
-	<xsl:variable name="surfaces" select="
-		//c:body/surface
-			[starts-with(@xml:id, $identifier || '-')] (: the surface's id must start with the id of the item, followed by a hyphen :)
-			[matches(@xml:id || '.xml', $page-identifier-regex)]
-	"/>
+	<xsl:variable name="surfaces" select="//c:body/surface"/>
 	
 	<xsl:variable name="ro-crate-upload" select="//c:body[contains(@disposition, 'name=&#34;ro-crate&#34;')]"/>
 	<xsl:variable name="ro-crate" select="parse-json($ro-crate-upload)"/>
@@ -66,14 +62,17 @@
 			</xsl:variable>
 			<xsl:apply-templates mode="reconstitute" select="$text-content"/>
 		</TEI>
-	<!--</xsl:result-document>-->
     </xsl:template>
     
     <xsl:mode name="surface-to-text" on-no-match="shallow-copy"/>
     
     <!-- <surface> container elements are replaced with <pb> milestone elements -->
     <xsl:template match="surface" mode="surface-to-text">
-    	<xsl:element name="pb"><xsl:copy-of select="@*"/></xsl:element>
+    	<xsl:element name="pb">
+    	     <xsl:copy-of select="@*"/>
+            <!-- create a new xml:id attribute, overriding whatever xml:id the surface may have had, based on the TEI page file name -->
+            <xsl:attribute name="xml:id" select="parent::c:body/@disposition => substring-after('filename=&#34;') => substring-before('.tei.xml')"/>
+    	</xsl:element>
     	<xsl:apply-templates mode="surface-to-text"/>
     </xsl:template>
     


### PR DESCRIPTION
See https://github.com/CoEDL/nyingarn-workspace/issues/191#issuecomment-1692888939 for a diagnosis of the problem, and a suggested fix which I've implemented here in this PR.

I modified `reconstitute.xsl` to export all `surface` elements, whether their `xml:id` attributes match the identifier regex or not. 

Previously, the `pb` elements in the resulting TEI would have `xml:id` attributes copied from the `surface` elements; now the `xml:id` values are taken from the name of the file containing that `surface` (with the `.tei.xml` extension removed).

I think the OCR-ingestion should be changed as well, so that it gives the `surface` elements `xml:id` values that match the convention used elsewhere (i.e. matching the file name, minus extension), but I haven't done that in this PR, yet. 

NB as it stands, this fix will enable existing TEI content in Nyingarn's storage that was ingested via OCR and has unconventional `surface/@xml:id` values to be exported in a form that can be reingested (once the user changed the file name to remove `-complete`), so it's not critical to change the OCR ingestion, but I still think it would be worth doing.